### PR TITLE
refactor(dependency): Remove lodash

### DIFF
--- a/config/env/index.js
+++ b/config/env/index.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import _ from 'lodash';
 
 const env = process.env.NODE_ENV || 'development';
 const config = require(`./${env}`);
@@ -8,6 +7,4 @@ const defaults = {
   root: path.join(__dirname, '/..')
 };
 
-_.assign(config, defaults);
-
-export default config;
+export default Object.assign(defaults, config);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "helmet": "2.1.1",
     "http-status": "^0.2.0",
     "joi": "8.4.2",
-    "lodash": "^4.0.1",
     "method-override": "^2.3.5",
     "mongoose": "^4.3.7",
     "morgan": "1.7.0",


### PR DESCRIPTION
`lodash` library is used only once in `config/env/index.js` file. I replaced that invocation with standard `Object.assign` method and deleted dependency.