### PR TITLE
chore(gitignore): update gitignore to avoid pushing OS generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,15 @@ pids
 # IDE
 .idea
 
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+ehthumbs.db
+Icon?
+Thumbs.db
+
 # Babel ES6 compiles files
 dist
 


### PR DESCRIPTION
Currently the OS generated files for example: .DS_Store gets pushed to remote. The reason was

because no extensions were listed to ignore OS generated files. Added a script to ignore unnecessary

OS generated files.