### PR TITLE
Fix limit and skip query params for get users route

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -61,7 +61,7 @@ function update(req, res, next) {
  */
 function list(req, res, next) {
   const { limit = 50, skip = 0 } = req.query;
-  User.list({ limit, skip })
+  User.list({ limit: parseInt(limit, 10), skip: parseInt(skip, 10) })
     .then(users => res.json(users))
     .catch(e => next(e));
 }


### PR DESCRIPTION
Mongo 3.2 requires limit and skip query params to be passed as Ints.

https://jira.mongodb.org/browse/DOCS-6995
