### PR TITLE
Use del.sync instead of del

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -14,7 +14,7 @@ const paths = {
 
 // Clean up dist and coverage directory
 gulp.task('clean', () =>
-  del(['dist/**', 'coverage/**', '!dist', '!coverage'])
+  del.sync(['dist/**', 'coverage/**', '!dist', '!coverage'])
 );
 
 // Copy non-js files to dist


### PR DESCRIPTION
Use `del.sync` instead of `del` as pointed out by @ouzhou
REF: https://github.com/KunalKapadia/express-mongoose-es6-rest-api/issues/184