### PR TITLE
Added mockgoose

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { Mockgoose } from 'mockgoose';
 import util from 'util';
 
 // config should be imported before importing any other file
@@ -15,7 +16,17 @@ mongoose.Promise = Promise;
 
 // connect to mongo db
 const mongoUri = `${config.mongo.host}:${config.mongo.port}`;
-mongoose.connect(mongoUri, { server: { socketOptions: { keepAlive: 1 } } });
+
+if (process.env.NODE_ENV === 'test') {
+  const mockgoose = new Mockgoose(mongoose);
+
+  mockgoose.prepareStorage().then(function () {
+    mongoose.connect('mongodb://example.com/test-db');
+  })
+} else {
+  mongoose.connect(mongoUri, { server: { socketOptions: { keepAlive: 1 } } });
+}
+
 mongoose.connection.on('error', () => {
   throw new Error(`unable to connect to database: ${config.db}`);
 });

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ const mongoUri = `${config.mongo.host}:${config.mongo.port}`;
 if (process.env.NODE_ENV === 'test') {
   const mockgoose = new Mockgoose(mongoose);
 
-  mockgoose.prepareStorage().then(function () {
+  mockgoose.prepareStorage().then(() => {
     mongoose.connect('mongodb://example.com/test-db');
-  })
+  });
 } else {
   mongoose.connect(mongoUri, { server: { socketOptions: { keepAlive: 1 } } });
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "esw *.js server config --color",
     "lint:watch": "yarn lint -- --watch",
     "precommit": "yarn lint && yarn test",
-    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive",
+    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --timeout 12000 --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive",
     "test:watch": "yarn test -- --watch",
-    "test:coverage": "cross-env NODE_ENV=test ./node_modules/.bin/istanbul cover _mocha -- --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive",
+    "test:coverage": "cross-env NODE_ENV=test ./node_modules/.bin/istanbul cover _mocha -- --timeout 12000 --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive",
     "test:check-coverage": "yarn test:coverage && istanbul check-coverage",
     "report-coverage": "coveralls < ./coverage/lcov.info"
   },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "husky": "^0.13.1",
     "istanbul": "1.1.0-alpha.1",
     "mocha": "3.2.0",
+    "mockgoose": "^7.0.7",
     "run-sequence": "^1.1.5",
     "supertest": "2.0.1",
     "supertest-as-promised": "4.0.2",

--- a/server/tests/user.test.js
+++ b/server/tests/user.test.js
@@ -1,21 +1,9 @@
-import mongoose from 'mongoose';
 import request from 'supertest-as-promised';
 import httpStatus from 'http-status';
 import chai, { expect } from 'chai';
 import app from '../../index';
 
 chai.config.includeStack = true;
-
-/**
- * root level hooks
- */
-after((done) => {
-  // required because https://github.com/Automattic/mongoose/issues/1251#issuecomment-65793092
-  mongoose.models = {};
-  mongoose.modelSchemas = {};
-  mongoose.connection.close();
-  done();
-});
 
 describe('## User APIs', () => {
   let user = {


### PR DESCRIPTION
Mockgoose uses an in-memory version of mongodb so tests start fresh each time and no database is polluted should certain tests fail.

Edit: one thing ive noticed with Mockgoose is that if your internet is slow (or not available), the first test that uses mockgoose will fail with `timeout exceeded`. I think this is because mockgoose is checking if the prebuilt mongodb binary is up to date. Not sure this is acceptable for this project but personally I'm okay with it. See https://github.com/Mockgoose/Mockgoose/issues/20