### PR TITLE
Change mongoUri constant to be mongo host only.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ Promise = require('bluebird'); // eslint-disable-line no-global-assign
 mongoose.Promise = Promise;
 
 // connect to mongo db
-const mongoUri = `${config.mongo.host}:${config.mongo.port}`;
+const mongoUri = config.mongo.host;
 mongoose.connect(mongoUri, { server: { socketOptions: { keepAlive: 1 } } });
 mongoose.connection.on('error', () => {
   throw new Error(`unable to connect to database: ${config.db}`);


### PR DESCRIPTION
for some reason, the mongo port was also included in the mongoUri, so when mongoose.connect called, the DB created is: HOST_NAME:27017 - unnecessary port use.