### PR TITLE
Fix deprecation warnings on mongoose connection options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,28 +1,34 @@
-const mongoose = require('mongoose');
-const util = require('util');
+const mongoose = require("mongoose");
+const util = require("util");
 
 // config should be imported before importing any other file
-const config = require('./config/config');
-const app = require('./config/express');
+const config = require("./config/config");
+const app = require("./config/express");
 
-const debug = require('debug')('express-mongoose-es6-rest-api:index');
+const debug = require("debug")("express-mongoose-es6-rest-api:index");
 
 // make bluebird default Promise
-Promise = require('bluebird'); // eslint-disable-line no-global-assign
+Promise = require("bluebird"); // eslint-disable-line no-global-assign
 
 // plugin bluebird promise in mongoose
 mongoose.Promise = Promise;
 
 // connect to mongo db
 const mongoUri = config.mongo.host;
-mongoose.connect(mongoUri, { server: { socketOptions: { keepAlive: 1 } } });
-mongoose.connection.on('error', () => {
+
+mongoose.connect(mongoUri, {
+  keepAlive: true,
+  useNewUrlParser: true,
+  useCreateIndex: true,
+  useFindAndModify: false
+});
+mongoose.connection.on("error", () => {
   throw new Error(`unable to connect to database: ${mongoUri}`);
 });
 
 // print mongoose logs in dev env
 if (config.mongooseDebug) {
-  mongoose.set('debug', (collectionName, method, query, doc) => {
+  mongoose.set("debug", (collectionName, method, query, doc) => {
     debug(`${collectionName}.${method}`, util.inspect(query, false, 20), doc);
   });
 }


### PR DESCRIPTION
Fix deprecation warnings on mongoose connection options. You can get more information on [here](https://mongoosejs.com/docs/deprecations.html)