### PR TITLE
Fixed issue where Travis wouldn't look for environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,8 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH=$HOME/.yarn/bin:$PATH
 env:
-  - JWT_SECRET=asecuresecret
+  - NODE_ENV=development
+  - PORT=4040
+  - JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
+  - MONGO_HOST=mongodb://localhost:27017/express-mongoose-es6-rest-api-development
+  - MONGO_PORT=27017

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ after_script:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH=$HOME/.yarn/bin:$PATH
+env:
+  - JWT_SECRET=asecuresecret

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,4 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH=$HOME/.yarn/bin:$PATH
 env:
-  - NODE_ENV=development
-  - PORT=4040
-  - JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
-  - MONGO_HOST=mongodb://localhost:27017/express-mongoose-es6-rest-api-development
-  - MONGO_PORT=27017
+  - NODE_ENV=development PORT=4040 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f MONGO_HOST=mongodb://localhost:27017/express-mongoose-es6-rest-api-development MONGO_PORT=27017


### PR DESCRIPTION
I noticed when making my [automated documentation pr](https://github.com/kunalkapadia/express-mongoose-es6-rest-api/pull/464) that there was an issue with travis, so I looked into fixing it

## Key Changes
- Added the required `environment` variables to `travis.yml`